### PR TITLE
Use extras_require[test] instead of tests_require

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,10 @@ install_requires =
   dirhash
   GitPython
 packages = find:
-tests_require =
+zip_safe = true
+
+[options.extras_require]
+test =
   flake8>=3.6.0
   flake8-blind-except
   flake8-builtins
@@ -46,7 +49,6 @@ tests_require =
   pytest
   pytest-cov
   scspell3k>=2.2
-zip_safe = true
 
 [options.packages.find]
 exclude = test


### PR DESCRIPTION
> This will align the test requirement expression mechanism with the reset of the colcon packages.

https://github.com/ruffsl/colcon-clean/pull/15