### PR TITLE
Update stdeb.cfg based on availability of python3-scantree

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,5 +1,5 @@
 [colcon-cache]
 No-Python2:
-Depends3: python3-colcon-core (>= 0.5.2)
-Suite: xenial bionic focal stretch buster
-X-Python3-Version: >= 3.5
+Depends3: python3-colcon-core (>= 0.5.2), python3-dirhash, python3-scantree
+Suite: jammy
+X-Python3-Version: >= 3.6


### PR DESCRIPTION
> The only supported Debian or Ubuntu version that has python3-scantree is
Jammy, so that's the only one we can build a deb for.

https://github.com/ruffsl/colcon-clean/pull/14

> Fix stdeb syntax

https://github.com/ruffsl/colcon-clean/pull/17