### PR TITLE
Specify target module when analyzing coverage

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -89,3 +89,4 @@ import-order-style = google
 
 [coverage:run]
 branch = True
+source = colcon_cache


### PR DESCRIPTION
> This seems to help avoid coverage for other modules unexpectedly bleeding into the results.

https://github.com/ruffsl/colcon-clean/pull/20