### PR TITLE
Ignore a deprecation warning in flake8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -60,6 +60,7 @@ exclude = test
 [tool:pytest]
 filterwarnings =
     error
+    ignore::DeprecationWarning:flake8:
     ignore::DeprecationWarning:scantree.*:
     ignore::PendingDeprecationWarning:scspell:
     ignore::pytest.PytestUnraisableExceptionWarning


### PR DESCRIPTION
Because of `filterwarnings = error`, this deprecation is becoming an error under certain circumstances:
```
DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.
```