### PR TITLE
Suppress desktop notifications within integration tests

### DIFF
--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -2,6 +2,7 @@ acdmr
 andhus
 apache
 basepath
+blocklist
 chdir
 checksum
 checksums

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -17,6 +17,9 @@ def test_main():
 
     os.chdir(ws_base)
     argv = []
+    os.environ['COLCON_EXTENSION_BLOCKLIST'] = (
+        'colcon_core.event_handler.desktop_notification:' +
+        os.environ.get('COLCON_EXTENSION_BLOCKLIST', ''))
 
     try:
         main(argv=argv + ['build'])


### PR DESCRIPTION
This is a quick way to suppress the desktop notifications getting generated whenever these tests get executed. It's confusing to see the various success and failure notifications coming up while the test is still in-progress. Feel free to expand the extension blocklist here - any extra stuff that you can disable will only make the test run faster.