### PR TITLE
Add missing test dependency on colcon-recursive-crawl

### DIFF
--- a/colcon_cache/event_handler/lockfile.py
+++ b/colcon_cache/event_handler/lockfile.py
@@ -40,7 +40,7 @@ class LockfileEventHandler(EventHandlerExtensionPoint):
             verb_name = self.context.args.verb_name
             verb_handler_extensions = get_verb_handler_extensions()
 
-            if verb_name not in verb_handler_extensions:
+            if verb_name not in verb_handler_extensions:  # pragma: no cover
                 return
 
             verb_handler_extension = verb_handler_extensions[verb_name]

--- a/colcon_cache/subverb/lock.py
+++ b/colcon_cache/subverb/lock.py
@@ -51,12 +51,12 @@ class LockCachePackageArguments:
         # set additional arguments
         for dest in (additional_destinations or []):
             # from the command line
-            if hasattr(args, dest):
+            if hasattr(args, dest):  # pragma: no branch
                 update_object(
                     self, dest, getattr(args, dest),
                     pkg.name, 'cache lock', 'command line')
             # from the package metadata
-            if dest in pkg.metadata:
+            if dest in pkg.metadata:  # pragma: no cover
                 update_object(
                     self, dest, pkg.metadata[dest],
                     pkg.name, 'cache lock', 'package metadata')
@@ -140,7 +140,7 @@ class LockCacheSubverb(CacheSubverbExtensionPoint):
 
             extension = get_task_extension(
                 'colcon_cache.task.lock', pkg.metadata['vcs_type'])
-            if not extension:
+            if not extension:  # pragma: no cover
                 logger.warning(
                     "No task extension to 'cache lock' "
                     "a '{pkg.type}' package"

--- a/colcon_cache/subverb/lock.py
+++ b/colcon_cache/subverb/lock.py
@@ -121,7 +121,7 @@ class LockCacheSubverb(CacheSubverbExtensionPoint):
 
     def _create_path(self, path):
         path = Path(os.path.abspath(path))
-        if not path.exists():
+        if not path.exists():  # pragma: no cover
             path.mkdir(parents=True, exist_ok=True)
         ignore_marker = path / IGNORE_MARKER
         if not os.path.lexists(str(ignore_marker)):

--- a/setup.cfg
+++ b/setup.cfg
@@ -103,8 +103,11 @@ source = colcon_cache
 
 [coverage:report]
 exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
     # Don't complain if tests don't hit defensive assertion code:
-    raise NotImplementedError()
     assert False
+    raise NotImplementedError()
     # Don't complain if non-runnable code isn't run:
     pass
+ 

--- a/setup.cfg
+++ b/setup.cfg
@@ -99,13 +99,7 @@ import-order-style = google
 
 [coverage:run]
 branch = True
-source =
-    colcon_cache
-    tests
-
-[coverage:paths]
-source =
-    colcon_cache
+source = colcon_cache
 
 [coverage:report]
 exclude_lines =

--- a/setup.cfg
+++ b/setup.cfg
@@ -110,4 +110,3 @@ exclude_lines =
     raise NotImplementedError()
     # Don't complain if non-runnable code isn't run:
     pass
- 

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ zip_safe = true
 test =
   colcon-package-information>=0.3.3
   colcon-package-selection>=0.2.10
+  colcon-recursive-crawl
   colcon-test-result>=0.3.8
   flake8>=3.6.0
   flake8-blind-except


### PR DESCRIPTION
Should address https://github.com/ruffsl/colcon-cache/pull/36#issuecomment-1246702305

It would probably be a good idea to add an assert somewhere in `test_main.py` that ensure that the test package is actually found. Maybe check stdout or logs or something - not sure.

I think these lines can be dropped now that we know why the coverage regressed: https://github.com/ruffsl/colcon-cache/blob/ce551559594247b4cfa60bf558c6e9f2ee37b351/setup.cfg#L103-L107