### PR TITLE
Use unittest.mock instead of standalone mock

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,6 @@ test =
   flake8-docstrings
   flake8-import-order
   flake8-quotes
-  mock
   pep8-naming
   pylint
   pytest

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -42,5 +42,6 @@ symlink
 tempfile
 thomas
 todo
+unittest
 unmerged
 wildcard

--- a/test/test_verb.py
+++ b/test/test_verb.py
@@ -1,9 +1,10 @@
 # Copyright 2021 Ruffin White
 # Licensed under the Apache License, Version 2.0
 
+from unittest.mock import Mock
+
 from colcon_cache.verb.cache import CacheVerb
 from colcon_core.command import CommandContext
-from mock import Mock
 
 
 class Object(object):


### PR DESCRIPTION
The standalone 'mock' package is not needed for any supported versions of Python.