### PR TITLE
Fix Python 3.14 compatibility in dirhash job count

### DIFF
--- a/colcon_cache/task/lock/dirhash.py
+++ b/colcon_cache/task/lock/dirhash.py
@@ -205,8 +205,8 @@ class DirhashLockTask(TaskExtensionPoint):
             with suppress(AttributeError):
                 # consider restricted set of CPUs if applicable
                 jobs = min(jobs, len(os.sched_getaffinity(0)))
-            # if the number of cores can't be determined
-            jobs = max(filter(None.__ne__, [1, jobs]))
+            # if the number of cores can't be determined, fall back to 1
+            jobs = max(j for j in (1, jobs) if j is not None)
             args.dirhash_jobs = jobs
 
         kwargs = vars(args).copy()


### PR DESCRIPTION
This PR is making the script compatible with python 3.14 that is used by default in Ubuntu resolute